### PR TITLE
Fix 【总控--课程资源--直播单元：课次二次编辑出现以下错误提示】

### DIFF
--- a/app/Models/LiveChild.php
+++ b/app/Models/LiveChild.php
@@ -386,7 +386,8 @@ class LiveChild extends Model {
 //                );
                 // 更新 课次 绑定的 CC 直播间的 信息
                 $CCCloud = new CCCloud();
-                $room_info = $CCCloud ->update_room_info($data['course_id'],$data['title'],$data['title'],$data['barrage']);
+                $room_info = $CCCloud ->update_room_info($CourseLiveClassChild->course_id, $one->name,
+                    $one->name,$one->barrage);
 
 
                 if($room_info['code'] == 0){


### PR DESCRIPTION
    https://www.tapd.cn/52737952/bugtrace/bugs/view/1152737952001000629
    bug 原因：更新cc直播间房间信息的时候信息错误导致